### PR TITLE
Add support for OrientDB 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DEBUG="waterline-orientdb:*,-waterline-orientdb:*:debug"
   matrix:
     - ORIENTDB_VERSION=1.7.10
+    - ORIENTDB_VERSION=2.0.2
 deploy:
   provider: npm
   email: npm@appscot.com

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Creates edge between specified two model instances by ID in the form parameters 
 usage: 
   ```javascript
   //Assume a model named "Post"
-  Post.createEdge('#12:1','#13:1',{'@class':'Comments'},function(err, result){
+  Post.createEdge('#12:1', '#13:1', { '@class':'Comments' }, function(err, result){
   
   });
   ```
@@ -109,11 +109,31 @@ Deletes edges between specified two model instances by ID in the form parameters
 usage: 
   ```javascript
   //Assume a model named "Post"
-  Post.deleteEdges('#12:1','#13:1',null,function(err, result){
+  Post.deleteEdges('#12:1', '#13:1', null, function(err, result){
   
   });
   ```
+
+###### `query(connection, collection, query, [options], cb)`
+Runs a SQL query against the database using Oriento's query method. Will attempt to convert @rid's into ids.
   
+usage: 
+  ```javascript
+  // Assume a model named "Friend"
+  Friend.query("SELECT FROM friendTable WHERE name='friend query'", function(err, retrievedUsers){
+  	console.log(retrievedUsers);
+  });
+  
+  // Using params
+  Friend.query("SELECT FROM friendTable WHERE name=:name", {
+    params: {
+      name: 'friend query'
+    }
+  }, function(err, retrievedUsers){
+  	console.log(retrievedUsers);
+  });
+  ```
+
 ###### `getDB(connection, collection, cb)`
 Returns a native Oriento object
   

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -315,6 +315,22 @@ module.exports = (function() {
     },
     
     /**
+     * Query
+     * 
+     * Runs a SQL query against the database using Oriento's query method
+     * Will attempt to convert @rid's into ids.
+     * 
+     * @param {Object} connection
+     * @param {Object} collection
+     * @param {String} query
+     * @param {String} options
+     * @param {Object} cb
+     */
+    query : function(connection, collection, query, options, cb) {
+      return connections[connection].query(query, options, cb);
+    },
+    
+    /**
      * Get DB
      * 
      * Returns the native OrientDB Object

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -523,24 +523,18 @@ module.exports = (function () {
       edge = this.associations.getEdge(collection, options);
     }
     
-    var query;
     if (edge) {
       // Create edge
       options['@class'] = collection;
-      edge.keys.forEach(function(refKey) {
-        delete options[refKey];
-      });
-      query = this.db.edge.from(edge.from).to(edge.to).create(options);
-    }
-    else {
-      query = this.db.insert()
-        .into(collection)
-        .set(options)
-        .transform(transformers)
-        .one();
+      edge.keys.forEach(function(refKey) { delete options[refKey]; });
+      return this.createEdge(edge.from, edge.to, options, cb);
     }
     
-    query
+    this.db.insert()
+      .into(collection)
+      .set(options)
+      .transform(transformers)
+      .one()
       .then(function(res) {
         cb(null, utils.rewriteIds(res, attributes));
       })
@@ -630,15 +624,26 @@ module.exports = (function () {
 
   /*
    * Creates edge between two vertices pointed by from and to
+   * Keeps the same interface as described in:
+   * https://github.com/codemix/oriento/blob/6b8c40e7f1f195b591b510884a8e05c11b53f724/README.md#creating-an-edge-with-properties
+   * 
    */
   DbHelper.prototype.createEdge = function(from, to, options, cb) {
+    var attributes,
+        klass = 'E';
     cb = cb || _.noop;
+    options = options || {};
+    
+    if(options['@class']){
+      klass = options['@class'];
+      attributes = this.collections[klass] && this.collections[klass].attributes;
+    }
 
-    this.db.edge.from(from).to(to).create(options)
+    this.db.create('EDGE', klass).from(from).to(to)
+      .set(options)
+      .one()
       .then(function(res) {
-        if (res.length === 1)
-          res = res[0];
-        cb(null, utils.rewriteIds(res));
+        cb(null, utils.rewriteIds(res, attributes));
       })
       .error(function(err) {
         cb(err);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -598,46 +598,30 @@ module.exports = (function () {
    * Deletes a document from a collection
    */
   DbHelper.prototype.destroy = function(collection, options, cb) {
-    var _query, where, attributes;
-    var collectionInstance = this.collections[collection];
-    attributes = collectionInstance.attributes;
-    var schema = collectionInstance.waterline.schema;
-
-    if (options.where && utils.isJunctionTableThrough(collectionInstance)) {
-      var edge = this.associations.getEdge(collection, options.where);
-      if (!edge.from || !edge.to)
-        return cb(null, null);
-      return this.deleteEdges(edge.from, edge.to, { '@class' : collection }, cb);
-    }
+    var self = this;
+    cb = cb || _.noop;
     
-    // Catch errors from building query and return to the callback
-    try {
-      _query = new Query(options, schema, this.config);
-      where = _query.getWhereQuery(collection);
-    } catch(e) {
-      log.error('Failed to compose destroy SQL query.', e);
-      return cb(e);
-    }
-
-    var query = this.db.delete()
-      .from(collection)
-      .transform(transformers)
-      .return('BEFORE');
-
-    if(where.query[0]){
-      query.where(where.query[0]);
-      if(where.params){
-        query.addParams(where.params);
-      }
-    }
-
-    query.all()
-      .then(function(res) {
-        cb(null, utils.rewriteIds(res, attributes));
-      })
-      .error(function(err) {
-        cb(err);
-      });
+    // TODO: should be in a transaction
+    self.find(collection, options, function(err, results){
+      if(err){ return cb(err); }
+      
+      if(results.length === 0){ return cb(null, results); }
+      
+      var rids = _.pluck(results, 'id');
+      log.info('deleting rids: ' + rids);
+      
+      self.db.delete('VERTEX')
+        .where('@rid in [' + rids.join(',') + ']')
+        .one()
+        .then(function (count) {
+          if(count !== rids.length){
+            log.warn('deleted count [' + count + '] does not match rids length [' + rids.length +
+              '], some vertices may not have been deleted');
+          }
+          cb(null, results);
+        })
+        .error(cb);
+    });
   };
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -454,6 +454,9 @@ module.exports = (function () {
     log.debug('OrientDB query:', query.query[0]);
     
     var opts = { params: query.params || {} };
+    if(query.params){
+      log.debug('params:', opts);
+    }
     if(options.fetchPlan){
       opts.fetchPlan = options.fetchPlan.where;
       log.debug('opts.fetchPlan:', opts.fetchPlan);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -387,38 +387,39 @@ module.exports = (function () {
     };
     
     
-    /*Query methods starts from here*/
 
-    DbHelper.prototype.query = function (collection, options, cb) {
-      var _query;
-    // Catch errors from building query and return to the callback
-    try {
-      _query = new Query(options, collection, this.config);
-    } catch(err) {
-      return cb(err);
+  /**
+   * query
+   * 
+   * exposes Oriento's query
+   */
+  DbHelper.prototype.query = function(query, options, cb) {
+    if (options && !cb) {
+      cb = options;
+      options = undefined;
     }
 
-        var query = this.db.query(_query.criteria);
+    this.db.query(query, options)
+      .all()
+      .then(function(res) {
+        cb(null, utils.rewriteIdsRecursive(res));
+      })
+      .error(cb);
+  };
 
-        query
-            .all()
-            .then(function (res) {
-                cb(null, utils.rewriteIdsRecursive(res));
-            })
-            .error(function (err) {
-                cb(err);
-            });
+  /**
+   * getDB
+   * 
+   * returns the oriento db object
+   */
+  DbHelper.prototype.getDB = function(cb) {
+    return cb(this.db);
+  };
 
-    };
-    
-    DbHelper.prototype.getDB = function (cb) {
-       return cb(this.db);
-    };
-    
-    DbHelper.prototype.getServer = function (cb) {
-       return cb(this.server);
-    };
-  
+  DbHelper.prototype.getServer = function(cb) {
+    return cb(this.server);
+  }; 
+
     
   /**
    * Retrieves records of class collection that fulfill the criteria in options

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -656,14 +656,15 @@ module.exports = (function () {
    */
   DbHelper.prototype.deleteEdges = function(from, to, options, cb) {
     cb = cb || _.noop;
-    
-    if(!options)
-      return this.db.edge.from(from).to(to).delete(options)
+        
+    if(!options){
+      return this.db.delete('EDGE').from(from).to(to).scalar()
         .then(function(count) {
           cb(null, count);
         });
+    }
     
-    // temporary workaround for issue: https://groups.google.com/forum/#!topic/orient-database/jlRFuFbdWNs
+    // temporary workaround for issue: https://github.com/orientechnologies/orientdb/issues/3114
     var className = _.isString(options) ? options : options['@class'];
     var command = 'DELETE EDGE FROM ' + from + ' TO ' + to + " where @class = '" + className + "'";
     this.db.query(command)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "oriento": "~1.1.0",
     "q": "^1.0.1",
     "waterline-cursor": "~0.0.5",
-    "waterline-sequel-orientdb": "~0.0.22"
+    "waterline-sequel-orientdb": "~0.0.23"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "~0.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterline-orientdb",
-  "version": "0.10.22",
+  "version": "0.10.30",
   "description": "OrientDB adapter for Waterline / Sails.js ORM",
   "main": "./lib/adapter.js",
   "scripts": {
@@ -15,11 +15,14 @@
   },
   "keywords": [
     "orientdb",
+    "orient",
     "orm",
     "waterline",
     "sails",
     "sailsjs",
-    "sails.js"
+    "sails.js",
+    "graph",
+    "graphdb"
   ],
   "author": {
     "name": "Dario Marcelino",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "~0.9.0",
     "debug": "~2.1.0",
     "debug-logger": "~0.2.0",
-    "lodash": "~3.1.0",
+    "lodash": "~3.2.0",
     "oriento": "~1.1.0",
     "q": "^1.0.1",
     "waterline-cursor": "~0.0.5",

--- a/test/integration-orientdb/tests/adapterCustomMethods/query.js
+++ b/test/integration-orientdb/tests/adapterCustomMethods/query.js
@@ -1,0 +1,63 @@
+var assert = require('assert'),
+    _ = require('lodash');
+
+describe('Adapter Custom Methods', function() {
+
+  describe('query', function() {
+    
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+    
+    var user;
+    
+    before(function(done) {
+      Associations.Friend.create({ name: 'friend query' }, function(err, createdUser) {
+        if(err) return done(err);
+        
+        user = createdUser;
+        done();
+      });
+    });
+    
+    after(function(done) {
+      Associations.Friend.destroy(user.id, done);
+    });
+    
+    
+    describe('query user', function() {
+      
+      /////////////////////////////////////////////////////
+      // TEST METHODS
+      ////////////////////////////////////////////////////
+      
+      it('should return user', function(done) {
+        Associations.Friend.query("SELECT FROM friendTable WHERE name='friend query'", function(err, retrievedUsers){
+          if (err) { done(err); }
+          assert.equal(retrievedUsers.length, 1);
+          assert.equal(retrievedUsers[0].id, user.id);
+          assert(!retrievedUsers[0]['@rid']);
+          done();
+        });       
+      });
+      
+      it('should return user using parameterized query', function(done) {
+        Associations.Friend.query("SELECT FROM friendTable WHERE name=:name", {
+          params: {
+            name: 'friend query'
+          }
+        }, function(err, retrievedUsers){
+          if (err) { done(err); }
+          assert.equal(retrievedUsers.length, 1);
+          assert.equal(retrievedUsers[0].id, user.id);
+          assert(!retrievedUsers[0]['@rid']);
+          done();
+        });       
+      });
+      
+    });
+    
+  });
+  
+  
+});

--- a/test/unit/utils.rewriteIds.test.js
+++ b/test/unit/utils.rewriteIds.test.js
@@ -76,6 +76,17 @@ describe('utils helper class', function() {
 
   describe('rewriteIdsRecursive:', function() {
     var functionToTest = 'rewriteIdsRecursive';
+    
+    it('invalid inputs', function(done) {
+      var result = utils.rewriteIdsRecursive(null);
+      assert.equal(result, null);
+      result = utils.rewriteIdsRecursive([]);
+      assert.equal(result.length, 0);
+      result = utils.rewriteIdsRecursive([{}]);
+      assert.equal(1, result.length);
+      assert.equal(result[0].id, undefined);
+      done();
+    });
 
     it('single level result set', function(done) {
       testSingleLevel(functionToTest);


### PR DESCRIPTION
* Support for OrientDB 2.0
* No longer using deprecated methods `db.edge.*`
* Fixes parameterised queries #20 (now it passes the tests)
* Exposes Oriento's `query` method