### PR TITLE
Issue #40: allows schemaless objects to be retrieved using '*'

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,7 @@ exports.rewriteIds = function rewriteIds(models, schema) {
     if(!_.isObject(model))
       return model;
     
-    if(hop.call(model, 'rid')) {
+    if(hop.call(model, 'rid') && self.matchRecordId(model.rid)) {
       // case where the @rid is a temporary one
       self.replaceKeyForId(model, 'rid');
       delete model['@rid'];

--- a/test/integration-orientdb/bootstrap.js
+++ b/test/integration-orientdb/bootstrap.js
@@ -35,7 +35,12 @@ var fixtures = {
   
   FriendFixture: require('./fixtures/hasManyThrough.friend.fixture'),
   FollowsFixture: require('./fixtures/hasManyThrough.follows.fixture'),
-  OwnsFixture: require('./fixtures/hasManyThrough.owns.fixture')
+  OwnsFixture: require('./fixtures/hasManyThrough.owns.fixture'),
+  
+  // bug fixtures below
+  Profile40Fixture: require('./fixtures/bugs/40.profile.fixture'),
+  SubprofileFixture: require('./fixtures/bugs/40.subprofile.fixture'),
+  ProfileconnectionFixture: require('./fixtures/bugs/40.profileconnection.fixture')
 };
 
 

--- a/test/integration-orientdb/fixtures/bugs/40.profile.fixture.js
+++ b/test/integration-orientdb/fixtures/bugs/40.profile.fixture.js
@@ -12,7 +12,7 @@ module.exports = Waterline.Collection.extend({
 
   attributes: {
 
-    //'*': '', // little hack to get all fields because no schema¬ 
+    '*': '', // little hack to get all fields because no schema¬ 
     profiles: {
       collection: 'Subprofile',
       through: 'profileconnection',

--- a/test/integration-orientdb/fixtures/bugs/40.profile.fixture.js
+++ b/test/integration-orientdb/fixtures/bugs/40.profile.fixture.js
@@ -1,0 +1,25 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+  
+  identity: 'profile40',
+  connection: 'associations',
+  schema: false,
+
+  attributes: {
+
+    //'*': '', // little hack to get all fields because no schema¬ 
+    profiles: {
+      collection: 'Subprofile',
+      through: 'profileconnection',
+      via: 'profile',
+      dominant: true
+    }
+
+  }
+
+});

--- a/test/integration-orientdb/fixtures/bugs/40.profileconnection.fixture.js
+++ b/test/integration-orientdb/fixtures/bugs/40.profileconnection.fixture.js
@@ -1,0 +1,35 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'profileconnection',
+  connection: 'associations',
+  schema: false,
+
+  attributes: {
+
+    profileRef: {
+      columnName: 'profileRef',
+      type: 'string',
+      foreignKey: true,
+      references: 'profile40',
+      on: 'id',
+      onKey: 'id',
+      via: 'subprofileRef'
+    },
+    subprofileRef: {
+      columnName: 'subprofileRef',
+      type: 'string',
+      foreignKey: true,
+      references: 'subprofile',
+      on: 'id',
+      onKey: 'id',
+      via: 'profileRef'
+    }
+  }
+
+});

--- a/test/integration-orientdb/fixtures/bugs/40.subprofile.fixture.js
+++ b/test/integration-orientdb/fixtures/bugs/40.subprofile.fixture.js
@@ -1,0 +1,22 @@
+/**
+ * Dependencies
+ */
+
+var Waterline = require('waterline');
+
+module.exports = Waterline.Collection.extend({
+
+  identity: 'subprofile',
+  connection: 'associations',
+  schema: false,
+
+  attributes: {
+    //'*': '', // little hack to get all fields because no schema¬ 
+    profiles: {
+      collection: 'profile40',
+      through: 'profileconnection',
+      via: 'subprofile',
+    }
+  }
+
+});

--- a/test/integration-orientdb/fixtures/bugs/40.subprofile.fixture.js
+++ b/test/integration-orientdb/fixtures/bugs/40.subprofile.fixture.js
@@ -11,7 +11,7 @@ module.exports = Waterline.Collection.extend({
   schema: false,
 
   attributes: {
-    //'*': '', // little hack to get all fields because no schema¬ 
+    '*': '', // little hack to get all fields because no schema¬ 
     profiles: {
       collection: 'profile40',
       through: 'profileconnection',

--- a/test/integration-orientdb/tests/bugs/40-object_instead_id.js
+++ b/test/integration-orientdb/tests/bugs/40-object_instead_id.js
@@ -1,0 +1,56 @@
+var assert = require('assert'),
+    _ = require('lodash'),
+    utils = require('../../../../lib/utils');
+
+describe('Bug #40 Returning object instead of id', function() {
+
+  /////////////////////////////////////////////////////
+  // TEST SETUP
+  ////////////////////////////////////////////////////
+
+  var profileRecord, subprofileRecord;
+
+  before(function(done) {
+    Associations.Profile40.create({ alias: 'juanito', birthday: "1-01-1980" }, function(err, profile) {
+      if(err) { return done(err); }
+      profileRecord = profile;
+      Associations.Subprofile.create({ name: 'juan' }, function(err, subprofile) {
+        if(err) { return done(err); }
+        subprofileRecord = subprofile;
+        
+        profileRecord.profiles.add(subprofileRecord.id);
+        profileRecord.save(function(err){
+          if(err) { return done(err); }
+          done();
+        });
+      });
+    });
+  });
+  
+  after(function(done){
+    Associations.Profile40.destroy(profileRecord.id);
+    Associations.Subprofile.destroy(profileRecord.id);
+    done();
+  });
+
+
+  /////////////////////////////////////////////////////
+  // TEST METHODS
+  ////////////////////////////////////////////////////
+  describe('find a profile', function() {
+    
+    it('should return a profile with a subprofile', function(done) {
+      Associations.Profile40.find()
+        .populate('profiles')
+        .then(function(profiles){
+          assert.equal(profiles.length, 1);
+          assert.equal(profiles[0].id, profileRecord.id);
+          done();
+        })
+        .catch(done);
+    });
+    
+  });
+
+  
+});


### PR DESCRIPTION
Fix for Issue #40
* Only assume `rid` is the @rid if it actually matches a RID.