### PR TITLE
runFunction() and synced methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ usage:
   });
   ```
 
-#### .query (query, [options], cb)
+#### .query (query [, options], cb)
 Runs a SQL query against the database using Oriento's query method. Will attempt to convert @rid's into ids.
   
 usage: 
@@ -240,7 +240,7 @@ usage:
   });
   ```
 
-#### .native (cb)
+#### .native ()
 Returns a native Oriento class
   
 usage: 
@@ -253,7 +253,7 @@ usage:
     });
   ```
 
-#### .getDB (cb)
+#### .getDB ()
 Returns a native Oriento database object
   
 usage: 
@@ -266,7 +266,7 @@ usage:
     });
   ```
 
-#### .getServer (cb)
+#### .getServer ()
 Returns a native Oriento connection
   
 usage: 
@@ -289,8 +289,8 @@ usage:
   	});
   ``` 
 
-#### .removeCircularReferences (object, cb)
-Convenience method that replaces circular references with `id` when one is available, otherwise it replaces the object with string '[Circular]'
+#### .removeCircularReferences (object)
+Convenience method that replaces circular references with `id` when one is available, otherwise it replaces the object with string '[Circular]'.
   
 usage: 
   ```javascript

--- a/README.md
+++ b/README.md
@@ -246,12 +246,11 @@ Returns a native Oriento class
 usage: 
   ```javascript
   //Assume a model named "Post"
-  Post.native(function(myClass){
-  	myClass.property.list()
-      .then(function (properties) {
-        console.log('The class has the following properties:', properties);
-      }
-  });
+  Post.native()
+  	.property.list()
+    .then(function (properties) {
+      console.log('The class has the following properties:', properties);
+    });
   ```
 
 #### .getDB (cb)
@@ -260,13 +259,11 @@ Returns a native Oriento database object
 usage: 
   ```javascript
   //Assume a model named "Post"
-  Post.getDB(function(db){
-    db.select('foo() as testresult').from('OUser').limit(1).one()
-      .then(function(res) {
-        // res contains the result of foo
-        console.log(res);
-      });
-  });
+  Post.getDB()
+    .class.list()
+    .then(function (classes) {
+      console.log('There are ' + classes.length + ' classes in the db:', classes);
+    });
   ```
 
 #### .getServer (cb)
@@ -274,12 +271,11 @@ Returns a native Oriento connection
   
 usage: 
   ```javascript
-  Post.getServer(function(server){
-    server.list()
-      .then(function (dbs) {
-        console.log('There are ' + dbs.length + ' databases on the server.');
-      });
-  });
+  Post.getServer()
+    .list()
+    .then(function (dbs) {
+      console.log('There are ' + dbs.length + ' databases on the server.');
+    });
   ``` 
   
 #### .runFunction (functionName [, ...])
@@ -290,7 +286,7 @@ usage:
   Post.runFunction('foo', 'arg1').from('OUser').limit(1).one()
     .then(function(res) {
       console.log(res.foo);  // res.foo contains the result of the function
-  });
+  	});
   ``` 
 
 #### .removeCircularReferences (object, cb)
@@ -299,9 +295,8 @@ Convenience method that replaces circular references with `id` when one is avail
 usage: 
   ```javascript
   //Assume a model named "Post"
-  Post.removeCircularReferences(posts, function(result){
-  	console.log(JSON.stringify(result));  // it's safe to stringify result
-  });
+  var result = Post.removeCircularReferences(posts);
+  console.log(JSON.stringify(result));  // it's safe to stringify result
   ```
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -281,6 +281,17 @@ usage:
       });
   });
   ``` 
+  
+#### .runFunction (functionName [, ...])
+Returns a prepared Oriento statement with query and params to run an OrientDB function.
+  
+usage: 
+  ```javascript
+  Post.runFunction('foo', 'arg1').from('OUser').limit(1).one()
+    .then(function(res) {
+      console.log(res.foo);  // res.foo contains the result of the function
+  });
+  ``` 
 
 #### .removeCircularReferences (object, cb)
 Convenience method that replaces circular references with `id` when one is available, otherwise it replaces the object with string '[Circular]'

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -440,7 +440,10 @@ module.exports = (function() {
      */
     removeCircularReferences : function(connection, collection, object, cb) {
       utils.removeCircularReferences(object);
-      cb(object);
+      if (cb) {
+        cb(object);
+      }
+      return object;
     },
     
     /**

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -438,6 +438,21 @@ module.exports = (function() {
     removeCircularReferences : function(connection, collection, object, cb) {
       utils.removeCircularReferences(object);
       cb(object);
+    },
+    
+    /**
+     * Run Function
+     * 
+     * Run an OrientDB server side function
+     * 
+     * @param {Object} connection
+     * @param {Object} collection
+     * @param {String} functionName - the name of the server function
+     * @param {...Object} object - will be passed to server function
+     */
+    runFunction : function(connection, collection, functionName) {
+      var args = Array.prototype.slice.call(arguments, 3);
+      return connections[connection].runFunction(functionName, args);
     }
   };
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -108,6 +108,9 @@ module.exports = (function() {
         // transport: binary | rest. Currently only binary is supported: https://github.com/codemix/oriento/issues/44
         transport : 'binary',
         //
+        // Sets the oriento logger for error, log and debug. e.g.: { debug: console.log.bind(console) }
+        orientoLogger : {},
+        //
         // database username, by default uses connection username set on config
         // databaseUser : null,
         //

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -295,7 +295,24 @@ Connection.prototype.getServer = function(cb) {
   return cb(this.server);
 }; 
 
+/**
+ * returns a select query with run function query and params
+ */
+Connection.prototype.runFunction = function(functionName, args) {
+  var query = functionName + '(';
+  var params = {};
+
+  var i;
+  for (i=0; i<args.length; i++){
+    query += i === 0 ? '' : ', ';
+    query += ':param' + i;
+    params['param' + i] = args[i];
+  }
+  query += ')';
   
+  return this.db.select(query).addParams(params);
+};
+
 /**
  * Retrieves records of class collection that fulfill the criteria in options
  */
@@ -374,7 +391,7 @@ Connection.prototype.createEdge = function(from, to, options, cb) {
       cb(null, utils.rewriteIds(res, schema));
     })
     .error(cb);
-}; 
+};
 
 
 /*
@@ -490,7 +507,7 @@ Connection.prototype._getOriento = function _getOriento(config) {
     enableRIDBags : false,
     useToken : false
   };
-
+  
   return new Oriento(orientoOptions);
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -505,7 +505,8 @@ Connection.prototype._getOriento = function _getOriento(config) {
     password : config.password,
     transport : config.options.transport,
     enableRIDBags : false,
-    useToken : false
+    useToken : false,
+    logger : config.options.orientoLogger
   };
   
   return new Oriento(orientoOptions);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -277,7 +277,10 @@ Connection.prototype.query = function(query, options, cb) {
  * returns the oriento collection object
  */
 Connection.prototype.native = function(collection, cb) {
-  return cb(this.collections[collection].databaseClass);
+  if(cb){
+    cb(this.collections[collection].databaseClass);
+  }
+  return this.collections[collection].databaseClass;
 };
 
 
@@ -285,14 +288,20 @@ Connection.prototype.native = function(collection, cb) {
  * returns the oriento db object
  */
 Connection.prototype.getDB = function(cb) {
-  return cb(this.db);
+  if(cb){
+    cb(this.db);
+  }
+  return this.db;
 };
 
 /**
  * returns the oriento object
  */
 Connection.prototype.getServer = function(cb) {
-  return cb(this.server);
+  if(cb){
+    cb(this.server);
+  }
+  return this.server;
 }; 
 
 /**

--- a/test/integration-orientdb/tests/adapterCustomMethods/getDB_Server.js
+++ b/test/integration-orientdb/tests/adapterCustomMethods/getDB_Server.js
@@ -32,14 +32,13 @@ describe('Adapter Custom Methods', function() {
       ////////////////////////////////////////////////////
       
       it('should return user', function(done) {
-        Associations.Friend.getDB(function(db){
-          db.select().from('friendTable').where({name: 'friend getDB'}).one()
-            .then(function(retrievedUser){
-              assert.equal(retrievedUser['@rid'].toString(), user.id);
-              done();
-            })
-            .catch(done);          
-        });
+        Associations.Friend.getDB()
+          .select().from('friendTable').where({name: 'friend getDB'}).one()
+          .then(function(retrievedUser){
+            assert.equal(retrievedUser['@rid'].toString(), user.id);
+            done();
+          })
+          .catch(done);          
       });
       
     });
@@ -55,14 +54,13 @@ describe('Adapter Custom Methods', function() {
       ////////////////////////////////////////////////////
       
       it('should return more than 0 dbs', function(done) {
-        Associations.Friend.getServer(function(server){
-          server.list()
-            .then(function (dbs) {
-              assert(dbs.length >= 1);
-              done();
-            })
-            .catch(done);
-        });
+        Associations.Friend.getServer()
+          .list()
+          .then(function (dbs) {
+            assert(dbs.length >= 1);
+            done();
+          })
+          .catch(done);
       });
     });
   });
@@ -76,10 +74,9 @@ describe('Adapter Custom Methods', function() {
       ////////////////////////////////////////////////////
       
       it('should return the collection\'s class name', function(done) {
-        Associations.Friend.native(function(collection){
-          assert(collection.name, 'friendTable');
-          done();
-        });
+        var collection = Associations.Friend.native();
+        assert(collection.name, 'friendTable');
+        done();
       });
     });
   });

--- a/test/integration-orientdb/tests/adapterCustomMethods/removeCircularReferences.js
+++ b/test/integration-orientdb/tests/adapterCustomMethods/removeCircularReferences.js
@@ -14,11 +14,10 @@ describe('Adapter Custom Methods', function() {
       collection1.circ = collection1;
       assert.throws(function() { JSON.stringify(collection1); });
       
-      Associations.Friend.removeCircularReferences(collection1, function(result){
-        assert.equal(result.circ, '#13:1');
-        assert.doesNotThrow(function() { JSON.stringify(result); });
-        done();
-      });
+      var result = Associations.Friend.removeCircularReferences(collection1);
+      assert.equal(result.circ, '#13:1');
+      assert.doesNotThrow(function() { JSON.stringify(result); });
+      done();
     });
     
   });

--- a/test/integration-orientdb/tests/adapterCustomMethods/runFunction.test.js
+++ b/test/integration-orientdb/tests/adapterCustomMethods/runFunction.test.js
@@ -1,0 +1,56 @@
+var assert = require('assert');
+
+describe('Adapter Custom Methods', function() {
+
+  describe('runFunction', function() {
+    
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+    
+    before(function(done) {
+      Associations.Friend.getDB(function(db) {
+        db.createFn('runme1', function(str, str2) {
+          str = str || '';
+          str2 = str2 || '';
+          return 'this ' + str + ' work' + str2;
+        })
+        .then(function() { done(); })
+        .catch(done);
+      });
+    });
+
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+    
+    it('should run a server function with 1 argument', function(done) {
+      Associations.Friend.runFunction('runme1', 'does').from('OUser').limit(1).one()
+        .then(function(res) {
+          assert.equal(res.runme1, "this does work");
+          done();
+        })
+        .catch(done);
+    });
+    
+    it('should run a server function without params', function(done) {
+      Associations.Friend.runFunction('runme1').from('OUser').limit(1).one()
+        .then(function(res) {
+          assert.equal(res.runme1, "this  work");
+          done();
+        })
+        .catch(done);
+    });
+    
+    it('should run a server function with multiple arguments', function(done) {
+      Associations.Friend.runFunction('runme1', 'does', '!').from('OUser').limit(1).one()
+        .then(function(res) {
+          assert.equal(res.runme1, "this does work!");
+          done();
+        })
+        .catch(done);
+    });
+    
+  });
+
+});


### PR DESCRIPTION
* Adds `runFunction()` to run server side DB functions;
* `native()`, `getDB()`, `getServer()` and `removeCircularReferences()` are now synced. The async calls with callback will still be supported for backwards compatibility but are no longer the preferred way of using these;
* Exposes Oriento logger config to adapter.