### PR TITLE
#60 create collections at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Waterline adapter for OrientDB. [Waterline](https://github.com/balderdashy/water
 >
 > We don't recommend using `migrate: 'alter'` as it has the nasty effect of deleting the data of all edges on a graphDB, leaving only data on the vertexes. 
 > Either use `'safe'` and migrate manually or use `'drop'` to completely reset the data and collections. In production
-> always use `'safe'`. We are currently pushing for a new kind of migration strategy named `'create'`, check [waterline issue #846](https://github.com/balderdashy/waterline/issues/846).
+> always use `'safe'`. We are currently pushing for a new migration strategy named `'create'`, check [waterline issue #846](https://github.com/balderdashy/waterline/issues/846). While this is not accepted/merged by waterline you can use the config option `createCollectionsAtStartup` which acts in similar fashion.
 
 
 Waterline-orientdb aims to work with Waterline v0.10.x and OrientDB v1.7.10 and later. While it may work with earlier versions, they are not currently supported, [pull requests are welcome](
@@ -114,6 +114,10 @@ var config = {
         removeCircularReferences : false,
         
         // migrations
+        //
+        // Waterline-orientdb will create missing collections/properties at startup in a "safish" manner
+        // Only works with `migration: safe` as it would be redundant otherwise
+        createCollectionsAtStartup : false,
         //
         // Drop tables without deleting edges/vertexes hence not ensuring graph consistency
         // Will speed up drop operations. Only works with migration: 'alter' or 'drop'

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -6,7 +6,10 @@
 var ensureNewline = process.env.NODE_ENV !== 'production';
 var log = require('debug-logger').config({ ensureNewline: ensureNewline })('waterline-orientdb:adapter'),
     Connection = require('./connection'),
-    utils = require('./utils');
+    utils = require('./utils'),
+    _ = require('lodash'),
+    async = require('async'),
+    migrateCreate = require('./migrateCreate');
     
 /**
  * waterline-orientdb
@@ -127,6 +130,10 @@ module.exports = (function() {
         
         // migrations
         //
+        // Waterline-orientdb will create missing collections/properties at startup in a "safish" manner
+        // Only works with `migration: safe` as it would be redundant otherwise
+        createCollectionsAtStartup : false,
+        //
         // Drop tables without deleting edges/vertexes hence not ensuring graph consistency
         // Will speed up drop operations. Only works with migration: 'alter' or 'drop'
         unsafeDrop : false,
@@ -154,6 +161,7 @@ module.exports = (function() {
      * @return {[type]} [description]
      */
     registerConnection : function(connection, collections, cb) {
+      var self = this;
       log.debug('registerConnection:', connection.database);
 
       if (!connection.identity)
@@ -164,7 +172,23 @@ module.exports = (function() {
       // e.g. connections[connection.identity] = new Database(connection,
       // collections);
       
-      connections[connection.identity] = new Connection(connection, collections, cb);
+      connections[connection.identity] = new Connection(connection, collections, function(err, res){
+        if(err) { return cb(err); }
+        
+        if(connection.options.createCollectionsAtStartup){
+          var collectionsArray = _.values(collections);
+          log.info('Creating', collectionsArray.length, 'collections in database...');
+          
+          async.eachSeries(collectionsArray, function(collection, next){
+            if(collection.migrate !== 'safe') { return next(); }
+            var collectionName = collection.tableName ? collection.tableName : collection.identity.toLowerCase();
+            migrateCreate(self, connection.identity, collectionName, collection.definition, next);
+          }, cb);
+          
+        } else {
+          cb(null, res);
+        }
+      });
     },
 
 
@@ -209,8 +233,8 @@ module.exports = (function() {
      */
     describe : function(connection, collection, cb) {
       log.debug('describe:', collection);
-      // Add in logic here to describe a collection (e.g. DESCRIBE TABLE
-      // logic)
+      // Add in logic here to describe a collection (e.g. DESCRIBE TABLE logic)
+      
       connections[connection].describe(collection, cb);
     },
     

--- a/lib/migrateCreate.js
+++ b/lib/migrateCreate.js
@@ -1,0 +1,61 @@
+/**
+ * This module is essentially a workaround for the lack of a "safish" migration option
+ * to create collections and properties by waterline core. To better understand the aim of this,
+ * take a look at: https://github.com/balderdashy/waterline/issues/846
+ */
+"use strict";
+
+/**
+ * Module dependencies
+ */
+var _ = require('lodash'),
+  async = require('async');
+
+
+
+/**
+ * Try and synchronize the underlying physical-layer schema
+ * in safely manner by only adding new collections and new attributes
+ * to work with our app's collections. (i.e. models)
+ *
+ * @param  {Function} cb
+ */
+module.exports = function(adapter, connection, collection, collectionSchema, cb) {
+  var self = adapter;
+
+  // Check that collection exists
+  self.describe(connection, collection, function afterDescribe(err, attrs) {
+
+    if(err) return cb(err);
+
+    // if it doesn't go ahead and add it and get out
+    if(!attrs) return self.define(connection, collection, collectionSchema, cb);
+    
+    // The collection we're working with
+    var collectionID = collection;
+    
+    // Remove hasMany association keys before sending down to adapter
+    var schema = _.clone(collectionSchema) || {};
+    Object.keys(schema).forEach(function(key) {
+      if(schema[key].type) return;
+      delete schema[key];
+    });
+    
+    // Iterate through each attribute in the new definition
+    // Used for keeping track of previously undefined attributes
+    // when updating the data stored at the physical layer.
+    var newAttributes = _.reduce(schema, function checkAttribute(newAttributes, attribute, attrName) {
+      if (!attrs[attrName]) {
+        newAttributes[attrName] = attribute;
+      }
+      return newAttributes;
+    }, {});
+    
+    // Add new attributes
+    async.eachSeries(_.keys(newAttributes), function (attrName, next) {
+      var attrDef = newAttributes[attrName];
+      self.addAttribute(connection, collectionID, attrName, attrDef, next);
+    }, cb);
+
+  });
+};

--- a/test/integration-orientdb/fixtures/migrateCreate.migrant.fixture.js
+++ b/test/integration-orientdb/fixtures/migrateCreate.migrant.fixture.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+
+  tableName: 'migrantTable',
+  identity: 'migrant',
+  connection: 'associations',
+  migrate: 'safe',
+
+  attributes: {
+    name: 'string'
+  }
+};

--- a/test/integration-orientdb/tests/define/migrateCreate.test.js
+++ b/test/integration-orientdb/tests/define/migrateCreate.test.js
@@ -1,0 +1,155 @@
+var assert = require('assert'),
+    _ = require('lodash');
+
+var self = this,
+    fixtures,
+    config,
+    enabledConfig;
+
+describe('Migration', function() {
+  before(function (done) {
+    
+    config = {
+      database : 'test_migrate_create',
+      options : {
+        createCollectionsAtStartup : false
+      }
+    };
+    
+    enabledConfig = {
+      database : 'test_migrate_create',
+      options : {
+        createCollectionsAtStartup : true
+      }
+    };
+  
+    fixtures = {
+      MigrantFixture : require('../../fixtures/migrateCreate.migrant.fixture')
+    };
+
+    CREATE_TEST_WATERLINE(self, config, fixtures, done);
+  });
+  after(function (done) {
+    DELETE_TEST_WATERLINE('test_migrate_create', done);
+  });
+
+
+  describe('createCollectionsAtStartup: false', function() {
+    
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+    
+    after(function (done) {
+      self.waterline.teardown(done);
+    });
+    
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+    
+    it('should have the proper migrate setting when bootstrapping', function() {
+      assert.equal(self.collections.Migrant.migrate, 'safe');
+    });
+    
+    it('should not have tables', function(done) {
+      self.collections.Migrant.describe(function(err, schema) {
+        assert(!err);
+        assert(!schema);
+        done();
+      });
+    });
+  });
+  
+  
+  describe('createCollectionsAtStartup: true', function() {
+    
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+    
+    before(function (done) {
+      CREATE_TEST_WATERLINE(self, enabledConfig, fixtures, function(err){
+        if(err) { return done(err); }
+        self.collections.Migrant.create({ name: 'charlie' }, done);
+      });
+    });
+    after(function (done) {
+      self.waterline.teardown(done);
+    });
+    
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+    
+    it('should have tables', function(done) {
+      self.collections.Migrant.describe(function(err, schema) {
+        assert(!err);
+        assert(schema);
+        assert(schema.name);
+        assert(!schema.age);
+        done();
+      });
+    });
+    
+    it('should have created record', function(done) {
+      self.collections.Migrant.findOne({ name: 'charlie' }, function(err, mig) {
+        assert(!err);
+        assert.equal(mig.name, 'charlie');
+        done();
+      });
+    });
+  });
+  
+  
+  describe('createCollectionsAtStartup: true, new property', function() {
+    
+    /////////////////////////////////////////////////////
+    // TEST SETUP
+    ////////////////////////////////////////////////////
+    
+    var newPropertyFixtures = {
+      MigrantFixture: _.cloneDeep(require('../../fixtures/migrateCreate.migrant.fixture'))
+    };
+    newPropertyFixtures.MigrantFixture.attributes.age = 'int';
+    
+    before(function (done) {
+      CREATE_TEST_WATERLINE(self, enabledConfig, newPropertyFixtures, function(err){
+        if(err) { return done(err); }
+        self.collections.Migrant.create({ name: 'chaplin', age: 5 }, done);
+      });
+    });
+    
+    /////////////////////////////////////////////////////
+    // TEST METHODS
+    ////////////////////////////////////////////////////
+    
+    it('should have previous records', function(done) {
+      self.collections.Migrant.findOne({ name: 'charlie' }, function(err, mig) {
+        assert(!err);
+        assert.equal(mig.name, 'charlie');
+        done();
+      });
+    });
+    
+    it('should have new property age', function(done) {
+      self.collections.Migrant.describe(function(err, schema) {
+        assert(!err);
+        assert(schema);
+        assert(schema.name);
+        assert(schema.age);
+        done();
+      });
+    });
+    
+    it('should have created record with age', function(done) {
+      self.collections.Migrant.findOne({ name: 'chaplin' }, function(err, mig) {
+        assert(!err);
+        assert.equal(mig.name, 'chaplin');
+        assert.equal(mig.age, 5);
+        done();
+      });
+    });
+  });
+  
+});


### PR DESCRIPTION
Fixes issue #60.

Temporary workaround for the lack of a waterline migration strategy to create tables/properties in *safish* manner.